### PR TITLE
fix: escape backslashes for Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ function loader(this: webpack.loader.LoaderContext, contents: string) {
         join(__dirname, "..", "dist", "gobridge.js"),
         "';",
         proxyBuilder(emittedFilename)
-      ].join("")
+      ].join("").replace(/\\/g, "\\\\")
     );
   });
 }


### PR DESCRIPTION
The current program generates invalid paths like `..snip.. webpack-golang-wasm-async-loaderdistgobridge.js` on Windows because backslashes are not escaped. This PR fixes the issue.