### PR TITLE
update readme: reflect that it works with go 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This is a loader for [webpack](https://webpack.js.org/) that is used for generat
 
 The JavaScript bridge that is then generated for webpack will expose the WebAssembly functions as a Promise for interacting with.
 
+Note: It works with `Go 1.12` for now. Stay tuned for updates :)
+
 ## webpack config
 
 ```js


### PR DESCRIPTION
It might create confusion to the users running Go 1.13 as they will get an error as depicted here: https://github.com/aaronpowell/webpack-golang-wasm-async-loader/issues/4
Clear instructions on the version might result in less issues.

Please suggest any changes :)