### PR TITLE
Ensure item.Type() is Number in example

### DIFF
--- a/example/node/src/main.go
+++ b/example/node/src/main.go
@@ -13,11 +13,13 @@ import (
 var global = js.Global()
 
 func add(this js.Value, args []js.Value) (interface{}, error) {
-	ret := 0
+	var ret float64
 
 	for _, item := range args {
-		val, _ := strconv.Atoi(item.String())
-		ret += val
+		if item.Type() == js.TypeNumber {
+			val := item.Float()
+			ret += val
+		}
 	}
 
 	return ret, nil

--- a/example/web/src/main.go
+++ b/example/web/src/main.go
@@ -13,11 +13,13 @@ import (
 var global = js.Global()
 
 func add(this js.Value, args []js.Value) (interface{}, error) {
-	ret := 0
+	var ret float64
 
 	for _, item := range args {
-		val, _ := strconv.Atoi(item.String())
-		ret += val
+		if item.Type() == js.TypeNumber {
+			val := item.Float()
+			ret += val
+		}
 	}
 
 	return ret, nil


### PR DESCRIPTION
Due to item.toString() might return <type value>, eg: <number 1>.

The val will always be 0 and get 0 when call add function.